### PR TITLE
Add PHP 8.4 support and require PHP 8.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.3', '8.4']
         dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "assoconnect/php-quality-config": "^1.16"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-intl": "*",
         "thecodingmachine/safe": "^3.0"
     },

--- a/src/AbsoluteDate.php
+++ b/src/AbsoluteDate.php
@@ -253,4 +253,3 @@ class AbsoluteDate implements \Stringable
         $this->initDatetime(array_values($data)[0]->format(self::DEFAULT_DATE_FORMAT), self::DEFAULT_DATE_FORMAT);
     }
 }
-

--- a/src/AbsoluteDate.php
+++ b/src/AbsoluteDate.php
@@ -180,7 +180,7 @@ class AbsoluteDate implements \Stringable
      * @param \DateTimeInterface|null $datetime Point in time to find the date from
      * @throws \Exception
      */
-    public static function createInTimezone(DateTimeZone $timezone, \DateTimeInterface $datetime = null): self
+    public static function createInTimezone(DateTimeZone $timezone, ?\DateTimeInterface $datetime = null): self
     {
         return new self(
             (new DateTimeImmutable('@' . (null === $datetime ? time() : $datetime->getTimestamp())))
@@ -195,7 +195,7 @@ class AbsoluteDate implements \Stringable
      * @param string $relative Relative format to use
      * @param ?DateTimeZone $timezone Timezone to use to get the right date
      */
-    public static function createRelative(string $relative = 'now', DateTimeZone $timezone = null): self
+    public static function createRelative(string $relative = 'now', ?DateTimeZone $timezone = null): self
     {
         if (null === $timezone) {
             $timezone = new DateTimeZone('UTC');

--- a/src/AbsoluteDate.php
+++ b/src/AbsoluteDate.php
@@ -253,3 +253,4 @@ class AbsoluteDate implements \Stringable
         $this->initDatetime(array_values($data)[0]->format(self::DEFAULT_DATE_FORMAT), self::DEFAULT_DATE_FORMAT);
     }
 }
+


### PR DESCRIPTION
## Summary
- Update minimum PHP requirement to 8.3
- Add PHP 8.4 to CI test matrix

## Changes
- Update composer.json to require PHP ^8.3
- Update GitHub Actions workflow to test on PHP 8.3 and 8.4

## Related
Part of organization-wide upgrade to standardize on PHP 8.3+ across all packages.

## Test plan
- [ ] CI tests pass on PHP 8.3
- [ ] CI tests pass on PHP 8.4